### PR TITLE
Achieve python 3.x compatibility.

### DIFF
--- a/qfp/db.py
+++ b/qfp/db.py
@@ -118,7 +118,7 @@ class QfpDB:
         """
         for x, y in fp.peaks:
             c.execute("""INSERT INTO Peaks
-                         VALUES (?,?,?)""", (recordid, x, y))
+                         VALUES (?,?,?)""", (recordid, x.item(), y.item()))
 
     def _store_hash(self, c, h):
         """
@@ -126,15 +126,17 @@ class QfpDB:
         """
         c.execute("""INSERT INTO Hashes
                      VALUES (null,?,?,?,?,?,?,?,?)""",
-                  (h[0], h[0], h[1], h[1], h[2], h[2], h[3], h[3]))
+                  (h[0].item(), h[0].item(), h[1].item(), h[1].item(),
+                   h[2].item(), h[2].item(), h[3].item(), h[3].item()))
 
     def _store_quad(self, c, q, recordid):
         """
         Inserts given quad into the Quads table
         """
         hashid = c.lastrowid
-        values = (hashid, recordid, q.A.x, q.A.y, q.C.x, q.C.y,
-                  q.D.x, q.D.y, q.B.x, q.B.y)
+        values = (hashid, recordid, q.A.x.item(), q.A.y.item(),
+                  q.C.x.item(), q.C.y.item(), q.D.x.item(), q.D.y.item(),
+                  q.B.x.item(), q.B.y.item())
         c.execute("""INSERT INTO Quads
                      VALUES (?,?,?,?,?,?,?,?,?,?)""", values)
 

--- a/qfp/quads.py
+++ b/qfp/quads.py
@@ -39,8 +39,8 @@ def _filter_peaks(root, peaks, r, c):
     if windowStart > lastPeak:
         return None
     windowEnd = windowStart + r
-    idx_start = bisect_left(peaks, (windowStart, None))
-    idx_end = bisect_right(peaks, (windowEnd, None))
+    idx_start = bisect_left(peaks, (windowStart, 0))
+    idx_end = bisect_right(peaks, (windowEnd, 0))
     filtered = peaks[idx_start:idx_end]
     if len(filtered) is 0:
         return None

--- a/qfp/utils.py
+++ b/qfp/utils.py
@@ -5,8 +5,13 @@ from numpy.lib import stride_tricks
 from scipy.ndimage.filters import maximum_filter, minimum_filter
 from bisect import bisect_left
 from collections import namedtuple
-from itertools import izip
 from heapq import nlargest
+
+try:
+    from itertools import izip
+except ImportError:  # python 3.x
+    izip = zip
+    xrange = range
 
 
 def stft(samples, framesize=1024, hopsize=32):


### PR DESCRIPTION
Mainly detecting `ImportError` and assigning replaceable function existing in python 3.x libraries.
```
try:
    from itertools import izip
except ImportError:  # python 3.x
    izip = zip
    xrange = range
```
---

Also fixes `TypeError` of message:
```
Traceback (most recent call last):
  File "test.py", line 12, in <module>
    db.query(fp_q)
  File "/Users/user/qfp/qfp/db.py", line 151, in query
    fp.match_candidates = self._find_match_candidates(fp)
  File "/Users/user/qfp/qfp/db.py", line 172, in _find_match_candidates
    self._filter_candidates(conn, c, qQuad, filtered)
  File "/Users/user/qfp/qfp/db.py", line 206, in _filter_candidates
    if not 1 / (1 + e) <= qQuad.A.y / cQuad.A.y <= 1 / (1 - e):
TypeError: ufunc 'true_divide' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```
Which happens if data are `INSERT`ed while having type `np.int64` or other numerical `numpy` types.
In order to store the actual numerical value, call `.item()` to the `np`-typed variables [reference](https://stackoverflow.com/questions/9452775/converting-numpy-dtypes-to-native-python-types).